### PR TITLE
fix(liquibase): escape key words for H2

### DIFF
--- a/src/main/java/io/surati/gap/payment/base/db/PaymentBaseDatabaseBuiltWithLiquibase.java
+++ b/src/main/java/io/surati/gap/payment/base/db/PaymentBaseDatabaseBuiltWithLiquibase.java
@@ -49,7 +49,8 @@ public final class PaymentBaseDatabaseBuiltWithLiquibase extends DataSourceWrap 
     public PaymentBaseDatabaseBuiltWithLiquibase(final DataSource src, final String contexts) {
         super(
             new UncheckedLiquibaseDataSource(
-                src, PaymentBaseDatabaseBuiltWithLiquibase.CHANGELOG_MASTER_FILENAME
+                src, PaymentBaseDatabaseBuiltWithLiquibase.CHANGELOG_MASTER_FILENAME,
+                contexts
             )
         );
     }

--- a/src/main/resources/io/surati/gap/payment/base/liquibase/postgresql/2022/001-initial-schema.xml
+++ b/src/main/resources/io/surati/gap/payment/base/liquibase/postgresql/2022/001-initial-schema.xml
@@ -50,7 +50,7 @@ SOFTWARE.
         id BIGSERIAL PRIMARY KEY,
         branch_code character varying(5) NOT NULL,
         number character varying(12) NOT NULL,
-        key character varying(2) NOT NULL,
+        "key" character varying(2) NOT NULL,
         bank_id bigint NOT NULL,
         holder_id bigint,
         CONSTRAINT pay_bank_account_bank_id_fkey FOREIGN KEY (bank_id) REFERENCES pay_bank (id)
@@ -123,10 +123,10 @@ SOFTWARE.
         SELECT ba.id,
         ba.branch_code,
         ba.number,
-        ba.key,
+        ba."key",
         ba.bank_id,
         ba.holder_id,
-        concat(b.code, ba.branch_code, ba.number, ba.key) AS full_number
+        concat(b.code, ba.branch_code, ba.number, ba."key") AS full_number
         FROM (pay_bank_account ba
         LEFT JOIN pay_third_party b ON ((b.id = ba.bank_id)));
 

--- a/src/test/java/io/surati/gap/payment/base/db/DbThirdPartiesTest.java
+++ b/src/test/java/io/surati/gap/payment/base/db/DbThirdPartiesTest.java
@@ -1,0 +1,43 @@
+package io.surati.gap.payment.base.db;
+
+import com.lightweight.db.EmbeddedPostgreSQLDataSource;
+import io.surati.gap.database.utils.extensions.DatabaseSetupExtension;
+import io.surati.gap.payment.base.api.ThirdParties;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+final class DbThirdPartiesTest {
+
+    @RegisterExtension
+    final DatabaseSetupExtension src = new DatabaseSetupExtension(
+        new PaymentBaseDatabaseBuiltWithLiquibase(
+            new EmbeddedPostgreSQLDataSource()
+        )
+    );
+
+    private ThirdParties items;
+
+    @BeforeEach
+    void setUp() {
+        this.items = new DbThirdParties(this.src);
+    }
+
+    @Test
+    void checksExistence() {
+        final String code = "T021";
+        MatcherAssert.assertThat(
+            "Should not contain code",
+            this.items.has(code),
+            Matchers.is(false)
+        );
+        this.items.add(code, "SURATI SAS", "SURATI");
+        MatcherAssert.assertThat(
+            "Should contain code",
+            this.items.has(code),
+            Matchers.is(true)
+        );
+    }
+}


### PR DESCRIPTION
We got word `key` in table pay_bank_account.
